### PR TITLE
Fix bug with some disallowed nodes

### DIFF
--- a/src/plugins/disallow-node.js
+++ b/src/plugins/disallow-node.js
@@ -30,7 +30,12 @@ function untangle(node, index, parent, mode) {
   if (mode === 'remove') {
     parent.children.splice(index, 1)
   } else if (mode === 'unwrap') {
-    const args = [index, 1].concat(node.children)
-    Array.prototype.splice.apply(parent.children, args)
+    var args = [index, 1];
+
+    if (node.children) {
+      args = args.concat(node.children);
+    }
+
+    Array.prototype.splice.apply(parent.children, args);
   }
 }

--- a/src/plugins/disallow-node.js
+++ b/src/plugins/disallow-node.js
@@ -30,7 +30,7 @@ function untangle(node, index, parent, mode) {
   if (mode === 'remove') {
     parent.children.splice(index, 1)
   } else if (mode === 'unwrap') {
-    var args = [index, 1];
+    let args = [index, 1];
 
     if (node.children) {
       args = args.concat(node.children);


### PR DESCRIPTION
This fixes a scenario when a disallowed node does not have children. Current code will evaluate `node.children` and add undefined to  `parent.children`'s array. This should not happen because the consumer code relies on a child not being `undefined`.

This problem manifests only when mode is `unwrap`.

An example of child with this problem is `thematicBreak` (`source: "***"`)